### PR TITLE
Fixes Default Buttons and Feedback Issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,8 @@ instance.prototype.init_feedbacks = function() {
 
 instance.prototype.feedback = function(feedback, bank) {
 	var self = this;
+
+	feedback.options.button = parseInt(feedback.options.button);
 	
 	if (feedback.type == 'blue') {
 		var buttonObj = self.keyStates.find(k => k.buttonNumber === feedback.options.button);
@@ -360,7 +362,7 @@ instance.prototype.actions = function() {
 					type: 'dropdown',
 					label: 'Button',
 					id: 'button',
-					default: '1',
+					default: '0',
 					choices: self.CHOICES_BUTTONS
 				}
 			]
@@ -372,6 +374,7 @@ instance.prototype.actions = function() {
 					type: 'dropdown',
 					label: 'Button',
 					id: 'button',
+					default: '0',
 					choices: self.CHOICES_BUTTONS
 				}
 			]


### PR DESCRIPTION
This PR should resolve #1 and #2

1. Is solved by ensuring the button ID reference is converted to an integer. The preset was defined as an integer, but the interface sets the option as a string
2. Is solved by ensuring the default button for the actions are set to '0' (the first button)

You may wish to resolve these issues another way.